### PR TITLE
feat: implement Option+drag element duplication

### DIFF
--- a/src/components/XMLTreeContainer.tsx
+++ b/src/components/XMLTreeContainer.tsx
@@ -45,6 +45,7 @@ const XMLTreeContainer: React.FC<XMLTreeContainerProps> = ({
     draggedElement,
     dropIndicator,
     isDragging,
+    isDuplicateMode,
     handleDragStart,
     handleDragOver,
     handleDragEnd,
@@ -115,6 +116,7 @@ const XMLTreeContainer: React.FC<XMLTreeContainerProps> = ({
                 isAnyDragActive={isDragging}
                 isValidDropTarget={isValidDropTarget(flatElement.id)}
                 isOverTarget={dropIndicator?.targetId === flatElement.id}
+                isDuplicateMode={isDuplicateMode}
                 onElementClick={handleElementClick}
                 onAddChild={onAddChild}
                 onDelete={onDelete}
@@ -149,7 +151,7 @@ const XMLTreeContainer: React.FC<XMLTreeContainerProps> = ({
       {/* Ghost element that follows cursor */}
       <DragOverlay>
         {draggedElement && (
-          <XMLTreeGhost element={draggedElement} />
+          <XMLTreeGhost element={draggedElement} isDuplicateMode={isDuplicateMode} />
         )}
       </DragOverlay>
       

--- a/src/components/XMLTreeGhost.tsx
+++ b/src/components/XMLTreeGhost.tsx
@@ -7,11 +7,13 @@ import type { FlatXMLElement } from '@/lib/tree-conversion';
 
 interface XMLTreeGhostProps {
   element: FlatXMLElement;
+  isDuplicateMode?: boolean;
   className?: string;
 }
 
 const XMLTreeGhost: React.FC<XMLTreeGhostProps> = ({ 
   element, 
+  isDuplicateMode,
   className 
 }) => {
   return (
@@ -20,8 +22,8 @@ const XMLTreeGhost: React.FC<XMLTreeGhostProps> = ({
         // Base ghost styling - subtle and elegant
         "xml-tree-ghost",
         "flex items-center gap-2 p-2 rounded",
-        "bg-gray-100 dark:bg-gray-800",
-        "border border-gray-300 dark:border-gray-600",
+        isDuplicateMode ? "bg-green-100 dark:bg-green-900/50" : "bg-gray-100 dark:bg-gray-800",
+        isDuplicateMode ? "border border-green-400 dark:border-green-600" : "border border-gray-300 dark:border-gray-600",
         "shadow-lg",
         // Transform for visual appeal (subtle tilt)
         "transform rotate-1",
@@ -67,6 +69,13 @@ const XMLTreeGhost: React.FC<XMLTreeGhostProps> = ({
         {element.content && (
           <span className="text-xs text-gray-500 dark:text-gray-400 truncate max-w-[100px] font-normal ml-1">
             {element.content}
+          </span>
+        )}
+
+        {/* Duplicate mode indicator */}
+        {isDuplicateMode && (
+          <span className="text-xs font-bold text-green-700 dark:text-green-300 bg-green-200 dark:bg-green-800 px-1 py-0.5 rounded ml-2">
+            COPY
           </span>
         )}
       </div>

--- a/src/components/XMLTreeItem.tsx
+++ b/src/components/XMLTreeItem.tsx
@@ -18,6 +18,7 @@ interface XMLTreeItemProps {
   isAnyDragActive: boolean;
   isValidDropTarget: boolean;
   isOverTarget: boolean;
+  isDuplicateMode?: boolean;
   onElementClick: (element: FlatXMLElement) => void;
   onAddChild: (elementId: string) => void;
   onDelete: (elementId: string) => void;
@@ -35,6 +36,7 @@ const XMLTreeItem: React.FC<XMLTreeItemProps> = ({
   isAnyDragActive,
   isValidDropTarget,
   isOverTarget,
+  isDuplicateMode,
   onElementClick,
   onAddChild,
   onDelete,
@@ -81,7 +83,9 @@ const XMLTreeItem: React.FC<XMLTreeItemProps> = ({
         !isSelected && "hover:bg-gray-100 dark:hover:bg-gray-800",
         isDragging && "z-50",
         // Only outline the current hovered drop target; keep it inside rounded edges
-        isOverTarget && !isDragging && "ring-2 ring-inset ring-blue-400/60"
+        isOverTarget && !isDragging && !isDuplicateMode && "ring-2 ring-inset ring-blue-400/60",
+        // Special styling for duplicate mode drops
+        isOverTarget && !isDragging && isDuplicateMode && "ring-2 ring-inset ring-green-400/60 bg-green-50/50"
       )}
       data-tree-item={element.id}
       data-testid={`tree-item-${element.id}`}
@@ -136,6 +140,13 @@ const XMLTreeItem: React.FC<XMLTreeItemProps> = ({
         {element.content && (
           <span className={`${isMobile ? 'text-xs' : 'text-xs'} text-gray-500 truncate max-w-[150px] font-normal ml-2`}>
             {element.content}
+          </span>
+        )}
+
+        {/* Duplicate mode indicator */}
+        {isDuplicateMode && isDragging && (
+          <span className="text-xs font-bold text-green-600 bg-green-100 px-1 py-0.5 rounded ml-2">
+            COPY
           </span>
         )}
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -52,3 +52,22 @@ export function generateUUID(): string {
     return v.toString(16);
   });
 }
+
+// Generate element ID using timestamp pattern (consistent with existing pattern)
+export function generateElementId(): string {
+  return `element-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+}
+
+// Deep clone XMLElement and assign new unique IDs to all elements in the tree
+export function duplicateXMLElement(element: any): any {
+  const duplicateRecursive = (el: any): any => {
+    const newId = generateElementId();
+    return {
+      ...el,
+      id: newId,
+      children: el.children && el.children.length > 0 ? el.children.map(duplicateRecursive) : []
+    };
+  };
+  
+  return duplicateRecursive(element);
+}


### PR DESCRIPTION
This PR implements element duplication functionality requested in issue #9.

## Summary

Users can now hold the Option/Alt key while dragging XML elements to duplicate them instead of moving them. This includes full support for duplicating elements with their children.

## Changes

- ✨ Added Option key detection during drag operations
- ✨ Implemented deep element cloning with unique ID generation
- ✨ Added visual feedback for duplication mode (green styling, "COPY" indicators)
- ✨ Support for duplicating elements with all their children
- ✨ Seamless integration with existing drag/drop system

## How to Test

1. Create some XML elements in the structure builder
2. Hold Option (Mac) or Alt (PC) key
3. Drag an element to a new position
4. Notice the green visual feedback and "COPY" indicator
5. Drop the element – it should be duplicated instead of moved

## Technical Implementation

- Modified `useXMLTreeDragDrop` hook to track Option key state
- Created `duplicateXMLElement()` utility for deep cloning with new IDs
- Enhanced UI components with duplication visual feedback
- Updated drag end handler to support both move and duplicate operations

Closes #9

🤖 Generated with [Claude Code](https://claude.ai/code)